### PR TITLE
feat: add username/password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A javascript client for notify_push events for Nextcloud apps.
 
 ## Installation
 
-```
-npm i -S @nextcloud/notify_push
+```sh
+npm i @nextcloud/notify_push
 ```
 
 ## Usage
@@ -15,7 +15,18 @@ npm i -S @nextcloud/notify_push
 ```js
 import { listen } from '@nextcloud/notify_push'
 
+// Using pre_auth request for web apps
 listen('notify_file', () => {
 	console.log('A File has been changed')
+})
+
+// Using credentials for clients
+listen('notify_file', () => {
+  console.log('A File has been changed')
+}, {
+  credentials: {
+    username: 'alice',
+    password: 'app-password',
+  },
 })
 ```


### PR DESCRIPTION
The `notify_push` app supports two types of authentication:
- using `pre_auth` request
- using username/password credentials

https://github.com/nextcloud/notify_push/blob/main/src/connection.rs#L248

But `notify_push-client` supports only `pre_auth` request. While it makes sense for Nextcloud web apps, for clients it might be useful to authenticate using app password as well. For example, for the Talk Desktop client, which currently uses a patched version of `@nextcloud/notify_push`.

This PR adds optional options to pass credentials.