### PR TITLE
fix: es interop with @nextcloud/axios

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,5 @@
 import {getCapabilities} from '@nextcloud/capabilities';
-// @ts-ignore, work around https://github.com/nextcloud-libraries/nextcloud-axios/issues/638
-import {post} from '@nextcloud/axios'
+import axios from '@nextcloud/axios'
 import {subscribe} from '@nextcloud/event-bus'
 
 declare global {
@@ -109,7 +108,7 @@ async function setupSocket(options: NotifyPushOptions = {}) {
 
 	let preAuth: string
 	if (!options.credentials) {
-		const response = await post(capabilities.notify_push.endpoints.pre_auth)
+		const response = await axios.post(capabilities.notify_push.endpoints.pre_auth)
 		preAuth = response.data
 	}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
+    "esModuleInterop": true,
     "lib": [
       "es6",
       "dom"


### PR DESCRIPTION
Fixes 2 issues:
- `import {post} from '@nextcloud/axios'`  is not a valid ES import. There is no `post` exported from `@nextcloud/axios`. It luckily worked when the module was only used in CJS with pure CJS because it is valid for `require`. But it is not valid for `import`.
- Library builds as `CJS` but uses other libraries. It's good to support importing modules with `_esModule` so "ESM-based" CJS libraries works fine. Enabled via `esModuleInterop: true`

Alternative solution could also be using any bundler like Rollup or Vite and build an ESM version as well. In most cases an ESM version is used in our infra.