### PR TITLE
release: v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/notify_push",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/notify_push",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/notify_push",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Fixes
* fix: esm interop with @nextcloud/axios by @ShGKme in https://github.com/nextcloud-libraries/notify_push-client/pull/10

## What's Changed
* ci: Add workflows to allow releasing the package by @susnux in https://github.com/nextcloud-libraries/notify_push-client/pull/9
* Bump @nextcloud/browserslist-config from 3.0.0 to 3.0.1 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/13
* fix: esm interop with @nextcloud/axios by @ShGKme in https://github.com/nextcloud-libraries/notify_push-client/pull/10
* Bump @nextcloud/capabilities from 1.0.4 to 1.2.0 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/16
* Bump typedoc from 0.25.7 to 0.25.13 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/15
* Bump @nextcloud/event-bus from 3.1.0 to 3.3.0 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/11
* Bump @nextcloud/axios from 2.4.0 to 2.5.0 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/12
* Bump typescript from 5.3.3 to 5.4.5 by @dependabot in https://github.com/nextcloud-libraries/notify_push-client/pull/14

## New Contributors
* @susnux made their first contribution in https://github.com/nextcloud-libraries/notify_push-client/pull/9
* @dependabot made their first contribution in https://github.com/nextcloud-libraries/notify_push-client/pull/13

**Full Changelog**: https://github.com/nextcloud-libraries/notify_push-client/compare/v1.2.0...v1.3.0