### PR TITLE
chore: prepare lib release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/notify_push",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/notify_push",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   },
   "author": "Nextcloud GmbH and Nextcloud contributors",
   "license": "AGPL-3.0-or-later",
+  "files": [
+    "dist",
+    "AUTHORS.md",
+    "LICENSES"
+  ],
   "keywords": [
     "nextcloud"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/notify_push",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A javascript client for notify_push events",
   "type": "module",
   "exports": {


### PR DESCRIPTION
added ~~.npmignore file~~ .files definition in package.json
  (present in some other libraries, required for `npm pack` to include dist directory)
do not merge before https://github.com/nextcloud-libraries/notify_push-client/pull/62 ?