### PR TITLE
fix: do not export internal globals declaration

### DIFF
--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare global {
+	interface Window {
+		_notify_push_listeners: { [event: string]: ((string, any) => void)[] },
+		_notify_push_ws: WebSocket | null | true,
+		_notify_push_online: boolean,
+		_notify_push_available: boolean,
+		_notify_push_error_count: number,
+		_notify_push_ready: boolean,
+	}
+}
+
+export {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,21 +1,11 @@
-/**
+/*
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 import {getCapabilities} from '@nextcloud/capabilities';
 import axios from '@nextcloud/axios'
 import {subscribe} from '@nextcloud/event-bus'
-
-declare global {
-	interface Window {
-		_notify_push_listeners: { [event: string]: ((string, any) => void)[] },
-		_notify_push_ws: WebSocket | null | true,
-		_notify_push_online: boolean,
-		_notify_push_available: boolean,
-		_notify_push_error_count: number,
-		_notify_push_ready: boolean,
-	}
-}
 
 type NotifyPushOptions = {
 	credentials?: {


### PR DESCRIPTION
The globals are only used internally and should not be part of the distributed files.