### PR TITLE
chore(tsconfig): we target bundlers so target is esnext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,17 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "target": "esnext",
+    "module": "esnext",
     "moduleResolution": "Bundler",
     "declaration": true,
-    "outDir": "./dist",
     "strict": true,
+    "noImplicitAny": false,
     "esModuleInterop": true,
     "lib": [
-      "es6",
-      "dom"
+      "ESNext",
+      "DOM"
     ],
-    "noImplicitAny": false
+    "rootDir": "lib",
+    "outDir": "./dist",
   }
 }


### PR DESCRIPTION
- target should be esnext as bundlers will take care of it
- prepare for Typescript v6 where `rootDir` will be mandatory